### PR TITLE
Switch to .NET 9 / C# 13

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -38,6 +38,12 @@ jobs:
         if: ${{ env.IS_RELEASE == 'true' }}
         run: python build/create_tag_body.py
 
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+          dotnet-quality: "preview"
+
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworkVersion>net8.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>net9.0</TargetFrameworkVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <RestoreAdditionalProjectSources>
       https://www.myget.org/F/apollo3zehn-dev/api/v3/index.json
     </RestoreAdditionalProjectSources>

--- a/src/Nexus.UI/Core/AppState.cs
+++ b/src/Nexus.UI/Core/AppState.cs
@@ -339,12 +339,12 @@ public class AppState : INotifyPropertyChanged
 
             var groupNames = (resource
                 .Properties
-                .GetStringArray(GROUP_KEY) ?? new string[] { "default" })
+                .GetStringArray(GROUP_KEY) ?? ["default"])
                 .Where(groupName => groupName is not null)
                 .Cast<string>();
 
             if (!groupNames.Any())
-                groupNames = new string[] { "default" };
+                groupNames = ["default"];
 
             foreach (var groupName in groupNames)
             {

--- a/src/Nexus.UI/Nexus.UI.csproj
+++ b/src/Nexus.UI/Nexus.UI.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.0-preview.6.24328.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0-preview.6.24328.4" />
     <PackageReference Include="MudBlazor" Version="6.16.0" />
     <PackageReference Include="SkiaSharp" Version="2.88.7" />
     <PackageReference Include="SkiaSharp.Views.Blazor" Version="2.88.7" />

--- a/src/Nexus/Core/CacheEntryWrapper.cs
+++ b/src/Nexus/Core/CacheEntryWrapper.cs
@@ -90,7 +90,7 @@ internal class CacheEntryWrapper : IDisposable
                 var slicedByteTargetBuffer = new CastMemoryManager<double, byte>(slicedTargetBuffer).Memory;
 
                 _stream.Seek(cacheOffset * sizeof(double), SeekOrigin.Begin);
-                await _stream.ReadAsync(slicedByteTargetBuffer, cancellationToken);
+                await _stream.ReadExactlyAsync(slicedByteTargetBuffer, cancellationToken);
 
                 if (currentEnd >= cachedInterval.End)
                     index++;
@@ -221,10 +221,10 @@ internal class CacheEntryWrapper : IDisposable
 
         for (int i = 0; i < cachedPeriodCount; i++)
         {
-            stream.Read(buffer);
+            stream.ReadExactly(buffer);
             var beginTicks = BitConverter.ToInt64(buffer);
 
-            stream.Read(buffer);
+            stream.ReadExactly(buffer);
             var endTicks = BitConverter.ToInt64(buffer);
 
             cachedIntervals[i] = new Interval(

--- a/src/Nexus/Nexus.csproj
+++ b/src/Nexus/Nexus.csproj
@@ -6,12 +6,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0-preview.6.24328.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0-preview.6.24328.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.6.24327.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-preview.6.24327.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0-preview.6.24327.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -28,7 +28,6 @@
     <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="StreamJsonRpc" Version="2.17.11" />
-    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nexus/Nexus.csproj
+++ b/src/Nexus/Nexus.csproj
@@ -28,6 +28,39 @@
     <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="StreamJsonRpc" Version="2.17.11" />
+
+    <!-- 
+      This direct dependency is only required because of the transitive dependency
+      System.Security.Cryptography.Xml (v4.5.0) which has a known moderate 
+      severity vulnerability: https://github.com/advisories/GHSA-vh55-786g-wjwj
+
+      dotnet dotnet nuget why src/Nexus/Nexus.csproj System.Security.Cryptography.Xml
+
+      TODO: Check if still required
+    -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.1" />
+
+    <!--
+      This direct dependency is only required because of the transitive dependency 
+      System.Drawing.Common (v4.7.0) which has a known critical severity
+      vulnerability: https://github.com/advisories/GHSA-rxg9-xrhp-64gj
+
+      dotnet dotnet nuget why src/Nexus/Nexus.csproj System.Drawing.Common
+
+      TODO: Check if still required
+    -->
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+
+    <!--
+      This direct dependency is only required because of the transitive dependency 
+      System.Formats.Asn1 (v8.0.0) which has a known high severity
+      vulnerability: https://github.com/advisories/GHSA-447r-wph3-92pm
+
+      dotnet dotnet nuget why src/Nexus/Nexus.csproj System.Formats.Asn1
+
+      TODO: Check if still required
+    -->
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/extensibility/dotnet-extensibility-tests/dotnet-extensibility-tests.csproj
+++ b/tests/extensibility/dotnet-extensibility-tests/dotnet-extensibility-tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0-preview.6.24327.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.7.0" />


### PR DESCRIPTION
Nexus v2 is currently in development and a new release should be created in autumn or winter this year. This coincidences with the .NET 9 / C# 13 release which both bring useful features to the .NET world. 

Therefore, we should switch to the .NET 9 Preview 6 SDK (and switch again when the next preview version comes out).

A prerequisite for further development is that we install .NET 9 (https://dotnet.microsoft.com/en-us/download/dotnet/9.0). Just download and unzip the content in your existing .NET folder and agree to overwrite when being asked.

This is the first merge request of a sequence of merge requests to make use of the new features.

The full v2 (incomplete?) roadmap can be found here: #131 Suggestions for more features are welcome :-)