### PR TITLE
Use stackalloc in combination with the new params collection improvements

### DIFF
--- a/src/Nexus/API/CatalogsController.cs
+++ b/src/Nexus/API/CatalogsController.cs
@@ -298,7 +298,7 @@ internal class CatalogsController(
             if (license is null)
             {
                 var catalogInfo = await catalogContainer.GetLazyCatalogInfoAsync(cancellationToken);
-                license = catalogInfo.Catalog.Properties?.GetStringValue([DataModelExtensions.LicenseKey]);
+                license = catalogInfo.Catalog.Properties?.GetStringValue(DataModelExtensions.LicenseKey);
             }
 
             return license;

--- a/src/Nexus/Extensibility/DataSource/DataSourceController.cs
+++ b/src/Nexus/Extensibility/DataSource/DataSourceController.cs
@@ -422,10 +422,10 @@ internal class DataSourceController(
                         .Where(request =>
                             request.CatalogItem.Resource.Properties is null ||
                             request.CatalogItem.Resource.Properties
-                                .GetIntValue([
+                                .GetIntValue(
                                     DataModelExtensions.NEXUS_KEY,
                                     DataModelExtensions.PIPELINE_POSITION_KEY
-                                ]) == pipelinePosition
+                                ) == pipelinePosition
                         )
                         .ToArray();
 

--- a/src/Nexus/Extensibility/DataSource/DataSourceController.cs
+++ b/src/Nexus/Extensibility/DataSource/DataSourceController.cs
@@ -59,7 +59,6 @@ internal class DataSourceController(
     DataOptions dataOptions,
     ILogger<DataSourceController> logger) : IDataSourceController
 {
-    private static readonly string[] _pipelinePositionPath = [DataModelExtensions.NEXUS_KEY, DataModelExtensions.PIPELINE_POSITION_KEY];
 
     internal readonly IReadOnlyDictionary<string, JsonElement>? _requestConfiguration = requestConfiguration;
 
@@ -422,7 +421,11 @@ internal class DataSourceController(
                     var currentReadRequests = readRequests
                         .Where(request =>
                             request.CatalogItem.Resource.Properties is null ||
-                            request.CatalogItem.Resource.Properties.GetIntValue(_pipelinePositionPath) == pipelinePosition
+                            request.CatalogItem.Resource.Properties
+                                .GetIntValue([
+                                    DataModelExtensions.NEXUS_KEY,
+                                    DataModelExtensions.PIPELINE_POSITION_KEY
+                                ]) == pipelinePosition
                         )
                         .ToArray();
 

--- a/src/Nexus/Extensions/Sources/Sample.cs
+++ b/src/Nexus/Extensions/Sources/Sample.cs
@@ -158,8 +158,8 @@ internal class Sample : IDataSource
                 // check credentials
                 if (catalog.Id == RemoteCatalogId)
                 {
-                    var user = Context.RequestConfiguration?.GetStringValue([typeof(Sample).FullName!, "user"]);
-                    var password = Context.RequestConfiguration?.GetStringValue([typeof(Sample).FullName!, "password"]);
+                    var user = Context.RequestConfiguration?.GetStringValue(typeof(Sample).FullName!, "user");
+                    var password = Context.RequestConfiguration?.GetStringValue(typeof(Sample).FullName!, "password");
 
                     if (user != RemoteUsername || password != RemotePassword)
                         throw new Exception("The provided credentials are invalid.");

--- a/src/Nexus/Extensions/Writers/Csv.cs
+++ b/src/Nexus/Extensions/Writers/Csv.cs
@@ -26,8 +26,6 @@ namespace Nexus.Writers;
     "https://github.com/nexus-main/nexus/blob/master/src/Nexus/Extensions/Writers/Csv.cs")]
 internal class Csv : IDataWriter, IDisposable
 {
-    private static readonly string[] _unitPath = [DataModelExtensions.UnitKey];
-
     private const string DESCRIPTION = """
     {
         "label":"CSV + Schema (*.csv)",
@@ -307,7 +305,7 @@ internal class Csv : IDataWriter, IDisposable
     private static string GetFieldName(CatalogItem catalogItem)
     {
         var unit = catalogItem.Resource.Properties?
-            .GetStringValue(_unitPath);
+            .GetStringValue([DataModelExtensions.UnitKey]);
 
         var fieldName = $"{catalogItem.Resource.Id}_{catalogItem.Representation.Id}{DataModelUtilities.GetRepresentationParameterString(catalogItem.Parameters)}";
 

--- a/src/Nexus/Extensions/Writers/Csv.cs
+++ b/src/Nexus/Extensions/Writers/Csv.cs
@@ -112,7 +112,7 @@ internal class Csv : IDataWriter, IDisposable
 
             if (!_resourceMap.TryGetValue(resourceFilePath, out var resource))
             {
-                var rowIndexFormat = Context.RequestConfiguration?.GetStringValue(["row-index-format"]) ?? "index";
+                var rowIndexFormat = Context.RequestConfiguration?.GetStringValue("row-index-format") ?? "index";
                 var constraints = new Constraints(Required: true);
 
                 var timestampField = rowIndexFormat switch
@@ -209,9 +209,9 @@ internal class Csv : IDataWriter, IDisposable
             .GroupBy(request => request.CatalogItem.Catalog.Id)
             .ToList();
 
-        var rowIndexFormat = Context.RequestConfiguration?.GetStringValue(["row-index-format"]) ?? "index";
+        var rowIndexFormat = Context.RequestConfiguration?.GetStringValue("row-index-format") ?? "index";
 
-        var significantFigures = int.Parse(Context.RequestConfiguration?.GetStringValue(["significant-figures"]) ?? "4");
+        var significantFigures = int.Parse(Context.RequestConfiguration?.GetStringValue("significant-figures") ?? "4");
         significantFigures = Math.Clamp(significantFigures, 0, 30);
 
         var groupIndex = 0;
@@ -305,7 +305,7 @@ internal class Csv : IDataWriter, IDisposable
     private static string GetFieldName(CatalogItem catalogItem)
     {
         var unit = catalogItem.Resource.Properties?
-            .GetStringValue([DataModelExtensions.UnitKey]);
+            .GetStringValue(DataModelExtensions.UnitKey);
 
         var fieldName = $"{catalogItem.Resource.Id}_{catalogItem.Representation.Id}{DataModelUtilities.GetRepresentationParameterString(catalogItem.Parameters)}";
 

--- a/src/Nexus/Services/AppStateManager.cs
+++ b/src/Nexus/Services/AppStateManager.cs
@@ -162,7 +162,7 @@ internal class AppStateManager(
             }
 
             var additionalInformation = attribute.Description;
-            var label = (additionalInformation?.GetStringValue([UI.Core.Constants.DATA_WRITER_LABEL_KEY])) ?? throw new Exception($"The description of data writer {fullName} has no label property");
+            var label = (additionalInformation?.GetStringValue(UI.Core.Constants.DATA_WRITER_LABEL_KEY)) ?? throw new Exception($"The description of data writer {fullName} has no label property");
             var version = dataWriterType.Assembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
                 .InformationalVersion;

--- a/src/extensibility/dotnet-extensibility/DataModel/DataModelExtensions.cs
+++ b/src/extensibility/dotnet-extensibility/DataModel/DataModelExtensions.cs
@@ -230,9 +230,9 @@ public static partial class DataModelExtensions
             var isModified = false;
             var newResources = new List<Resource>();
 
-            string[] originalNamePath = [OriginalNameKey];
-            string[] pipelinePositionPath = [NEXUS_KEY, PIPELINE_POSITION_KEY];
-            string[] groupsPath = [GroupsKey];
+            Span<string> originalNamePath = [OriginalNameKey];
+            Span<string> pipelinePositionPath = [NEXUS_KEY, PIPELINE_POSITION_KEY];
+            Span<string> groupsPath = [GroupsKey];
 
             foreach (var resource in catalog.Resources)
             {

--- a/src/extensibility/dotnet-extensibility/DataModel/DataModelExtensions.cs
+++ b/src/extensibility/dotnet-extensibility/DataModel/DataModelExtensions.cs
@@ -230,18 +230,19 @@ public static partial class DataModelExtensions
             var isModified = false;
             var newResources = new List<Resource>();
 
-            Span<string> originalNamePath = [OriginalNameKey];
-            Span<string> pipelinePositionPath = [NEXUS_KEY, PIPELINE_POSITION_KEY];
-            Span<string> groupsPath = [GroupsKey];
-
             foreach (var resource in catalog.Resources)
             {
                 var resourceProperties = resource.Properties;
                 var newResource = resource;
 
-                var originalName = resourceProperties?.GetStringValue(originalNamePath);
-                var currentPipelinePosition = resourceProperties?.GetIntValue(pipelinePositionPath);
-                var groups = resourceProperties?.GetStringArray(groupsPath);
+                var originalName = resourceProperties?
+                    .GetStringValue(OriginalNameKey);
+
+                var currentPipelinePosition = resourceProperties?
+                    .GetIntValue(NEXUS_KEY, PIPELINE_POSITION_KEY);
+
+                var groups = resourceProperties?
+                    .GetStringArray(GroupsKey);
 
                 var distinctGroups = groups is null
                     ? default

--- a/src/extensibility/dotnet-extensibility/DataModel/PropertiesExtensions.cs
+++ b/src/extensibility/dotnet-extensibility/DataModel/PropertiesExtensions.cs
@@ -17,10 +17,8 @@ public static class PropertiesExtensions
     /// <param name="properties">The properties.</param>
     /// <param name="pathSegments">The propery path segments.</param>
     /// <returns></returns>
-    public static string? GetStringValue(this IReadOnlyDictionary<string, JsonElement> properties, Span<string> pathSegments)
+    public static string? GetStringValue(this IReadOnlyDictionary<string, JsonElement> properties, params ReadOnlySpan<string> pathSegments)
     {
-        // TODO Maybe use params collection (Span) in future? https://github.com/dotnet/csharplang/issues/7700
-
         if (properties.TryGetValue(pathSegments[0], out var element))
         {
             pathSegments = pathSegments[1..];
@@ -44,7 +42,7 @@ public static class PropertiesExtensions
     /// <param name="properties">The properties.</param>
     /// <param name="pathSegments">The propery path segments.</param>
     /// <returns></returns>
-    public static string? GetStringValue(this JsonElement properties, Span<string> pathSegments)
+    public static string? GetStringValue(this JsonElement properties, params ReadOnlySpan<string> pathSegments)
     {
         var root = properties.GetJsonObjectFromPath(pathSegments[0..^1]);
         var propertyName = pathSegments[^1];
@@ -66,7 +64,7 @@ public static class PropertiesExtensions
     /// <param name="properties">The properties.</param>
     /// <param name="pathSegments">The property path segments.</param>
     /// <returns></returns>
-    public static string?[]? GetStringArray(this IReadOnlyDictionary<string, JsonElement> properties, Span<string> pathSegments)
+    public static string?[]? GetStringArray(this IReadOnlyDictionary<string, JsonElement> properties, params ReadOnlySpan<string> pathSegments)
     {
         if (properties.TryGetValue(pathSegments[0], out var element))
         {
@@ -96,7 +94,7 @@ public static class PropertiesExtensions
     /// <param name="properties">The properties.</param>
     /// <param name="pathSegments">The property path segments.</param>
     /// <returns></returns>
-    public static string?[]? GetStringArray(this JsonElement properties, Span<string> pathSegments)
+    public static string?[]? GetStringArray(this JsonElement properties, params ReadOnlySpan<string> pathSegments)
     {
         var root = properties.GetJsonObjectFromPath(pathSegments[0..^1]);
         var propertyName = pathSegments[^1];
@@ -116,7 +114,7 @@ public static class PropertiesExtensions
         return default;
     }
 
-    internal static int? GetIntValue(this IReadOnlyDictionary<string, JsonElement> properties, Span<string> pathSegments)
+    internal static int? GetIntValue(this IReadOnlyDictionary<string, JsonElement> properties, params ReadOnlySpan<string> pathSegments)
     {
         if (properties.TryGetValue(pathSegments[0], out var element))
         {
@@ -132,7 +130,7 @@ public static class PropertiesExtensions
         return default;
     }
 
-    internal static int? GetIntValue(this JsonElement properties, Span<string> pathSegments)
+    internal static int? GetIntValue(this JsonElement properties, params ReadOnlySpan<string> pathSegments)
     {
         var root = properties.GetJsonObjectFromPath(pathSegments[0..^1]);
         var propertyName = pathSegments[^1];
@@ -148,7 +146,7 @@ public static class PropertiesExtensions
         return default;
     }
 
-    private static JsonElement GetJsonObjectFromPath(this JsonElement root, Span<string> pathSegements)
+    private static JsonElement GetJsonObjectFromPath(this JsonElement root, ReadOnlySpan<string> pathSegements)
     {
         if (pathSegements.Length == 0)
             return root;

--- a/src/extensibility/dotnet-extensibility/DataModel/ResourceCatalog.cs
+++ b/src/extensibility/dotnet-extensibility/DataModel/ResourceCatalog.cs
@@ -152,8 +152,6 @@ public partial record ResourceCatalog
             }
         }
 
-        string[] typePath = ["type"];
-
         var parametersAreOK =
 
             (representation.Parameters is null && parameters is null) ||
@@ -163,8 +161,8 @@ public partial record ResourceCatalog
 
                 parameters.ContainsKey(current.Key) &&
 
-                (current.Value.GetStringValue(typePath) == "input-integer" && long.TryParse(parameters[current.Key], out var _) ||
-                 current.Value.GetStringValue(typePath) == "select" /* no validation here */)));
+                (current.Value.GetStringValue(["type"]) == "input-integer" && long.TryParse(parameters[current.Key], out var _) ||
+                 current.Value.GetStringValue(["type"]) == "select" /* no validation here */)));
 
         if (!parametersAreOK)
             return false;

--- a/src/extensibility/dotnet-extensibility/DataModel/ResourceCatalog.cs
+++ b/src/extensibility/dotnet-extensibility/DataModel/ResourceCatalog.cs
@@ -161,8 +161,8 @@ public partial record ResourceCatalog
 
                 parameters.ContainsKey(current.Key) &&
 
-                (current.Value.GetStringValue(["type"]) == "input-integer" && long.TryParse(parameters[current.Key], out var _) ||
-                 current.Value.GetStringValue(["type"]) == "select" /* no validation here */)));
+                (current.Value.GetStringValue("type") == "input-integer" && long.TryParse(parameters[current.Key], out var _) ||
+                 current.Value.GetStringValue("type") == "select" /* no validation here */)));
 
         if (!parametersAreOK)
             return false;

--- a/src/extensibility/dotnet-extensibility/Extensibility/DataSource/DataSourceTypes.cs
+++ b/src/extensibility/dotnet-extensibility/Extensibility/DataSource/DataSourceTypes.cs
@@ -58,7 +58,7 @@ internal class ReadRequestManager : IDisposable
     public ReadRequestManager(CatalogItem catalogItem, int elementCount)
     {
         var byteCount = elementCount * catalogItem.Representation.ElementSize;
-        var originalResourceName = catalogItem.Resource.Properties!.GetStringValue([DataModelExtensions.OriginalNameKey])!;
+        var originalResourceName = catalogItem.Resource.Properties!.GetStringValue(DataModelExtensions.OriginalNameKey)!;
 
         /* data memory */
         var dataOwner = MemoryPool<byte>.Shared.Rent(byteCount);

--- a/tests/Nexus.Tests/DataSource/SampleDataSourceTests.cs
+++ b/tests/Nexus.Tests/DataSource/SampleDataSourceTests.cs
@@ -31,8 +31,8 @@ public class SampleDataSourceTests
 
         // assert
         var actualIds = actual.Resources!.Select(resource => resource.Id).ToList();
-        var actualUnits = actual.Resources!.Select(resource => resource.Properties?.GetStringValue(["unit"])).ToList();
-        var actualGroups = actual.Resources!.SelectMany(resource => resource.Properties?.GetStringArray(["groups"]) ?? []);
+        var actualUnits = actual.Resources!.Select(resource => resource.Properties?.GetStringValue([DataModelExtensions.UnitKey])).ToList();
+        var actualGroups = actual.Resources!.SelectMany(resource => resource.Properties?.GetStringArray([DataModelExtensions.GroupsKey]) ?? []);
         var actualDataTypes = actual.Resources!.SelectMany(resource => resource.Representations!.Select(representation => representation.DataType)).ToList();
 
         var expectedIds = new List<string>() { "T1", "V1", "unix_time1", "unix_time2" };

--- a/tests/Nexus.Tests/DataSource/SampleDataSourceTests.cs
+++ b/tests/Nexus.Tests/DataSource/SampleDataSourceTests.cs
@@ -31,8 +31,8 @@ public class SampleDataSourceTests
 
         // assert
         var actualIds = actual.Resources!.Select(resource => resource.Id).ToList();
-        var actualUnits = actual.Resources!.Select(resource => resource.Properties?.GetStringValue([DataModelExtensions.UnitKey])).ToList();
-        var actualGroups = actual.Resources!.SelectMany(resource => resource.Properties?.GetStringArray([DataModelExtensions.GroupsKey]) ?? []);
+        var actualUnits = actual.Resources!.Select(resource => resource.Properties?.GetStringValue(DataModelExtensions.UnitKey)).ToList();
+        var actualGroups = actual.Resources!.SelectMany(resource => resource.Properties?.GetStringArray(DataModelExtensions.GroupsKey) ?? []);
         var actualDataTypes = actual.Resources!.SelectMany(resource => resource.Representations!.Select(representation => representation.DataType)).ToList();
 
         var expectedIds = new List<string>() { "T1", "V1", "unix_time1", "unix_time2" };


### PR DESCRIPTION
C# 13 has a very neat feature (https://devblogs.microsoft.com/dotnet/csharp-13-explore-preview-features/#params-collections) which allows improving the following old style construct:

```cs
void DoSomething(ReadOnlySpan<string> pathSegments)
{
    //
}

string[] _pathSegments = new string[] { "A", "B" };

void MyMethod()
{
    DoSomething(_pathSegments);
}
```

To the following (note the use of `params` and the removal of the `_pathSegments` variable):

```cs
void DoSomething(params ReadOnlySpan<string> pathSegments)
{
    //
}

void MyMethod()
{
    DoSomething("A", "B");
}
```

With the advantage of less code and **less allocations**! The reason is that the `params` keyword can now be combined with the allocation-free stack-based `ReadOnlySpan<T>` type. So no garbage-collector affecting array allocations happen in the improved version anymore. Everything is allocated on the stack and automatically cleaned up when the method ends.

This approach will be used to improve the methods defined in the `PropertiesExtensions` class which supports the user to extract strings or arrays from a `JsonElement`, which most of the time occurs in combination with resource and resource catalog properties.

This class helps mimicking what is quite simple in javascript: `let result = myJsonData.Sub.Property`. This syntax is not possible in C# because JSON is not a natural part of the language and it is being represented by `JsonElement` instead. This `JsonElement` offers not simple way to get nested JSON data in a strongly-typed way and therefore `PropertiesExtensions` defines some extension methods to make the life easier for Nexus plugin developers (and for us as well). Here is an example of how to use the extension methods:

```cs
var currentPipelinePosition = resourceProperties?.GetIntValue("nexus", "pipeline-position");
```

This line of code will retrieve the `pipeline-position` value of the resource properties, if available:

![grafik](https://github.com/user-attachments/assets/7cc1e7c1-c574-4c80-a91d-0c6aa4114a3b)

This PR improves the API and usage of the API by reducing the number of LOC and by reducing the number of array allocations.